### PR TITLE
Parent tracking now includes first character of transition

### DIFF
--- a/include/suffix_tree/detail/access.hpp
+++ b/include/suffix_tree/detail/access.hpp
@@ -13,5 +13,10 @@ class node_access {
     static void remove_transition(Node& node, typename Node::char_type c) {
         node.tr_.erase(c);
     }
+
+    template <typename Node>
+    static void set_parent(Node& tgt, Node const& src) {
+        tgt.parent_ = src.parent_;
+    }
 };
 } // namespace st

--- a/include/suffix_tree/detail/insertion_context.hpp
+++ b/include/suffix_tree/detail/insertion_context.hpp
@@ -50,6 +50,7 @@ private:
             using std::data;
             auto& tr = orig_->find_transition(jmp1_);
             auto& tr2 = tr.dest_->find_transition(jmp2_);
+            node_access::set_parent(*tr2.dest_, *tr.dest_);
             tr.dest_ = std::move(tr2.dest_);
             tr.sub_str_ = sview_type(data(tr.sub_str_), size(tr.sub_str_) + size(tr2.sub_str_));
         }

--- a/include/suffix_tree/detail/suffix_tree_node.hpp
+++ b/include/suffix_tree/detail/suffix_tree_node.hpp
@@ -56,9 +56,10 @@ public:
     using self_type = suffix_tree_node;
     using allocator = typename AllocatorTraits::template rebind_alloc<self_type>;
     using transition_type = transition<self_type>;
+    using parent_pair = std::pair<char_type, self_type*>;
 
     // Disable the copy for now...
-    suffix_tree_node() : parent_(nullptr), link_(nullptr), tr_() {}
+    suffix_tree_node() : parent_({}, nullptr), link_(nullptr), tr_() {}
     suffix_tree_node(suffix_tree_node const&) = delete;
     suffix_tree_node& operator=(suffix_tree_node const&) = delete;
 
@@ -104,7 +105,7 @@ private:
         return empty_tr;
     }
 
-    suffix_tree_node *parent_; // The parent node for the current substring
+    parent_pair parent_; // The parent node for the current substring
     suffix_tree_node *link_;
     // The node has ownership of its children but not of its parent nor its
     // link

--- a/include/suffix_tree/suffix_tree.hpp
+++ b/include/suffix_tree/suffix_tree.hpp
@@ -185,7 +185,7 @@ return_label:
                 // labeled x.b
                 using memory::allocate_unique;
                 auto r = allocate_unique<node_type>(alloc_);
-                r->parent_ = n;
+                r->parent_ = { str[0], n };
                 // Let's define the label for the transition from r to tr dest_
                 auto t_end = sview_type(
                     data(tr.sub_str_) + size(str), // starts at x
@@ -200,6 +200,7 @@ return_label:
                 // with the proper label.
                 tr.sub_str_ = sview_type(data(tr.sub_str_), size(str));
                 tr.dest_ = std::move(r);
+                new_tr_it->second.dest_->parent_ = { new_tr_it->first, r.get() };
                 ctx.add_branch_op(n, tr.sub_str_[0], t_end[0]);
                 return { false, tr.dest_.get() };
             }
@@ -228,7 +229,7 @@ return_label:
                     )
                 )
             );
-            leaf_tr_it->second.dest_->parent_ = r;
+            leaf_tr_it->second.dest_->parent_ = { leaf_tr_it->first, r };
             ctx.add_leaf_op(r, substr.back());
             if (oldr != root_.get()) {
                 oldr->link_ = r;


### PR DESCRIPTION
This will allow to easily get back to a child when moving up using the
parent link