### PR TITLE
suffixtree: Tree API

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,5 +1,7 @@
 BasedOnStyle:  Mozilla
 
+ColumnLimit: 80
+
 AlignAfterOpenBracket: AlwaysBreak
 
 AllowAllArgumentsOnNextLine: false

--- a/meta/include/Penjing/Meta/CustomizationPoints/Mapped.hpp
+++ b/meta/include/Penjing/Meta/CustomizationPoints/Mapped.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Rerito
+// Copyright (c) 2021-2022, Rerito
 // SPDX-License-Identifier: MIT
 
 #pragma once
@@ -108,7 +108,7 @@ struct MappedAt : private OnFailedAccess
             Details::HasSecond< std::ranges::range_value_t< Range > >
     constexpr auto operator()(Range& range, Key&& key) const noexcept(
         noexcept(std::forward< Range >(range).find(std::forward< Key >(key))))
-        -> typename OnFailedAccess::MappedType<
+        -> typename OnFailedAccess::template MappedType<
             decltype((std::declval< std::ranges::range_reference_t< Range& > >()
                           .second)) >
     {

--- a/storage/include/Penjing/Storage/Bindings/StdMap.hpp
+++ b/storage/include/Penjing/Storage/Bindings/StdMap.hpp
@@ -1,0 +1,34 @@
+// Copyright (c) 2021, Rerito
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <map>
+#include <memory>
+
+#include <Penjing/Meta/CurryTemplate.hpp>
+
+namespace Penjing {
+namespace Storage {
+namespace Bindings {
+
+template<
+    typename StorageAlloc,
+    typename Compare = Meta::CurryTemplate< std::less > >
+class StdMap
+{
+public:
+    using AllocatorType = StorageAlloc;
+
+    template< typename K, typename V >
+    using StorageType = std::map<
+        K,
+        V,
+        typename Compare::template f< K >,
+        typename std::allocator_traits< StorageAlloc >::template rebind_alloc<
+            std::pair< K const, V > > >;
+};
+
+} // namespace Bindings
+} // namespace Storage
+} // namespace Penjing

--- a/suffixtree/include/Penjing/SuffixTree/Algorithm/CompareNodes.hpp
+++ b/suffixtree/include/Penjing/SuffixTree/Algorithm/CompareNodes.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Rerito
+// Copyright (c) 2021-2022, Rerito
 // SPDX-License-Identifier: MIT
 
 #pragma once
@@ -86,7 +86,7 @@ public:
         while (!std::ranges::empty(queue)) {
             auto const& [n1, n2] = queue.front();
 
-            if(n1.childrenCount() != n2.childrenCount()) {
+            if (n1.childrenCount() != n2.childrenCount()) {
                 return false;
             }
 

--- a/suffixtree/include/Penjing/SuffixTree/Algorithm/MutatingNodeAlgorithm.hpp
+++ b/suffixtree/include/Penjing/SuffixTree/Algorithm/MutatingNodeAlgorithm.hpp
@@ -1,9 +1,11 @@
-// Copyright (c) 2021, Rerito
+// Copyright (c) 2021-2022, Rerito
 // SPDX-License-Identifier: MIT
 
 #pragma once
 
 #include <utility>
+
+#include <Penjing/Meta/Access.hpp>
 
 #include "../Core/UnsafeTag.hpp"
 
@@ -13,29 +15,37 @@ namespace Algorithm {
 
 class MutatingNodeAlgorithm
 {
+private:
+    using AccessType = Meta::Access< MutatingNodeAlgorithm >;
+
 protected:
     template< typename Node >
     constexpr auto mutableTransition(Node& node, typename Node::CharType start)
         const noexcept(noexcept(node.mutableTransition({}, std::move(start))))
     {
-        return node.mutableTransition({}, std::move(start));
+        return node.mutableTransition(AccessType{}, std::move(start));
     }
 
     template< typename Node >
     constexpr auto& mutableTransitionUnsafe(
         Node& node,
         typename Node::CharType start) const
-        noexcept(noexcept(
-            node.mutableTransition({}, std::move(start), Core::UnsafeTag{})))
+        noexcept(noexcept(node.mutableTransition(
+            AccessType{},
+            std::move(start),
+            Core::UnsafeTag{})))
     {
-        return node.mutableTransition({}, std::move(start), Core::UnsafeTag{});
+        return node.mutableTransition(
+            AccessType{},
+            std::move(start),
+            Core::UnsafeTag{});
     }
 
     template< typename Node >
     constexpr void setLink(Node& node, typename Node::NodePtr link) const
         noexcept(noexcept(node.setLink({}, std::move(link))))
     {
-        node.setLink({}, std::move(link));
+        node.setLink(AccessType{}, std::move(link));
     }
 
     template< typename Node >
@@ -43,10 +53,15 @@ protected:
         Node& node,
         typename Node::StringViewType label,
         typename Node::NodePtr target) const
-        noexcept(noexcept(
-            node.addTransition({}, std::move(label), std::move(target))))
+        noexcept(noexcept(node.addTransition(
+            AccessType{},
+            std::move(label),
+            std::move(target))))
     {
-        return node.addTransition({}, std::move(label), std::move(target));
+        return node.addTransition(
+            AccessType{},
+            std::move(label),
+            std::move(target));
     }
 };
 

--- a/suffixtree/include/Penjing/SuffixTree/Algorithm/MutatingTreeAlgorithm.hpp
+++ b/suffixtree/include/Penjing/SuffixTree/Algorithm/MutatingTreeAlgorithm.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Rerito
+// Copyright (c) 2021-2022, Rerito
 // SPDX-License-Identifier: MIT
 
 #pragma once
@@ -14,6 +14,24 @@ protected:
     constexpr decltype(auto) addNode(Tree& tree, Args&&... args) const noexcept
     {
         return tree.addNode({}, std::forward< Args >(args)...);
+    }
+
+    template< typename Tree >
+    constexpr decltype(auto) mutableRoot(Tree& tree) const noexcept
+    {
+        return tree.mutableRoot({});
+    }
+
+    template< typename Tree >
+    constexpr auto nodeFactory(Tree& tree) const noexcept
+    {
+        return tree.nodeFactory({});
+    }
+
+    template< typename Tree >
+    constexpr decltype(auto) mutableStringStorage(Tree& tree) const noexcept
+    {
+        return tree.mutableStringStorage({});
     }
 };
 

--- a/suffixtree/include/Penjing/SuffixTree/Builders/TreeBuild.hpp
+++ b/suffixtree/include/Penjing/SuffixTree/Builders/TreeBuild.hpp
@@ -1,0 +1,58 @@
+// Copyright (c) 2022, Rerito
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "../Algorithm/MutatingTreeAlgorithm.hpp"
+
+#include "../Concepts/HasStringStorage.hpp"
+
+namespace Penjing {
+namespace SuffixTree {
+
+namespace CPO {
+
+class TreeBuild : public Algorithm::MutatingTreeAlgorithm
+{
+private:
+    template< typename Tree, typename... Args >
+        requires(Concepts::HasStringStorage< Tree >)
+    constexpr auto viewToInsert(Tree& tree, Args&&... args) const
+    {
+        using StrView = typename Tree::StringViewType;
+        auto const& newString =
+            mutableStringStorage(tree).emplace(std::forward< Args >(args)...);
+
+        return StrView{
+            std::ranges::begin(newString),
+            std::ranges::end(newString)};
+    }
+
+    template< typename Tree >
+    constexpr auto viewToInsert(Tree& tree, typename Tree::StringViewType word)
+        const noexcept
+    {
+        return word;
+    }
+
+public:
+    template< typename Builder, typename Tree, typename... Args >
+    constexpr void operator()(Builder&& build, Tree& tree, Args&&... args) const
+    {
+        std::forward< Builder >(build)(
+            mutableRoot(tree),
+            viewToInsert(tree, std::forward< Args >(args)...),
+            nodeFactory(tree));
+    }
+};
+
+} // namespace CPO
+
+inline namespace Cust {
+
+inline constexpr CPO::TreeBuild build = {};
+
+} // namespace Cust
+
+} // namespace SuffixTree
+} // namespace Penjing

--- a/suffixtree/include/Penjing/SuffixTree/Builders/Ukkonen.hpp
+++ b/suffixtree/include/Penjing/SuffixTree/Builders/Ukkonen.hpp
@@ -1,0 +1,34 @@
+// Copyright (c) 2022, Rerito
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "TreeBuild.hpp"
+#include "Ukkonen/Build.hpp"
+
+namespace Penjing {
+namespace SuffixTree {
+
+namespace CPO {
+
+struct Ukkonen
+{
+    template< typename Tree, typename... Args >
+    constexpr void operator()(Tree& tree, Args&&... args) const noexcept(
+        noexcept(build(Builders::ukkonen, tree, std::forward< Args >(args)...)))
+    {
+        build(Builders::ukkonen, tree, std::forward< Args >(args)...);
+    }
+};
+
+} // namespace CPO
+
+inline namespace Cust {
+
+// Convenience alias for the generic ukkonen tree build.
+inline constexpr CPO::Ukkonen ukkonenBuild = {};
+
+} // namespace Cust
+
+} // namespace SuffixTree
+} // namespace Penjing

--- a/suffixtree/include/Penjing/SuffixTree/Builders/Ukkonen/Build.hpp
+++ b/suffixtree/include/Penjing/SuffixTree/Builders/Ukkonen/Build.hpp
@@ -1,10 +1,13 @@
-// Copyright (c) 2021, Rerito
+// Copyright (c) 2021-2022, Rerito
 // SPDX-License-Identifier: MIT
 
 #pragma once
 
 #include "../../Algorithm/MutatingNodeAlgorithm.hpp"
 #include "../../Algorithm/Walk.hpp"
+
+#include "Canonize.hpp"
+#include "Update.hpp"
 
 namespace Penjing {
 namespace SuffixTree {
@@ -13,16 +16,9 @@ namespace Ukkonen {
 
 namespace CPO {
 
-template< typename Canonizer, typename Updater >
-class Build
-    : private Algorithm::MutatingNodeAlgorithm
-    , private Canonizer
-    , private Updater
+template< auto Canonize = Cust::canonize, auto Update = Cust::update<> >
+class Build : public Algorithm::MutatingNodeAlgorithm
 {
-private:
-    using Canonizer::canonize;
-    using Updater::update;
-
 private:
     // TODO: Write proper noexcept specifier
     template< typename Node, typename NodeFactory >
@@ -52,7 +48,7 @@ public:
 
             // label is the proper view on the string for the next insertion
             // However it still needs to be canonized
-            std::tie(activeNode, label) = update(
+            std::tie(activeNode, label) = Update(
                 root,
                 activeNode.get(),
                 toInsert,
@@ -60,7 +56,7 @@ public:
                 makeNode);
 
             auto [canonizedActiveNode, canonizedLabel] =
-                canonize(activeNode.get(), label);
+                Canonize(activeNode.get(), label);
             label = std::move(canonizedLabel);
 
             // To be able to properly perform the next insertion, we have to
@@ -96,8 +92,8 @@ private:
 
 inline namespace Cust {
 
-template< typename Canonizer, typename Updater >
-inline constexpr CPO::Build< Canonizer, Updater > build{};
+template< auto Canonize = canonize, auto Update = update<> >
+inline constexpr CPO::Build< Canonize, Update > build{};
 
 } // namespace Cust
 

--- a/suffixtree/include/Penjing/SuffixTree/Builders/Ukkonen/Build.hpp
+++ b/suffixtree/include/Penjing/SuffixTree/Builders/Ukkonen/Build.hpp
@@ -98,6 +98,10 @@ inline constexpr CPO::Build< Canonize, Update > build{};
 } // namespace Cust
 
 } // namespace Ukkonen
+
+// Convenience alias for the Ukkonen suffix tree builder.
+inline constexpr auto ukkonen = Ukkonen::build<>;
+
 } // namespace Builders
 } // namespace SuffixTree
 } // namespace Penjing

--- a/suffixtree/include/Penjing/SuffixTree/Builders/Ukkonen/Canonize.hpp
+++ b/suffixtree/include/Penjing/SuffixTree/Builders/Ukkonen/Canonize.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Rerito
+// Copyright (c) 2021-2022, Rerito
 // SPDX-License-Identifier: MIT
 
 #pragma once
@@ -80,17 +80,6 @@ inline namespace Cust {
 inline constexpr CPO::Canonize canonize{};
 
 } // namespace Cust
-
-struct CanonizePolicy
-{
-    template< typename Node, typename StrView >
-    constexpr auto canonize(Node const& node, StrView&& wordPath) const
-        noexcept(
-            noexcept(Cust::canonize(node, std::forward< StrView >(wordPath))))
-    {
-        return Cust::canonize(node, std::forward< StrView >(wordPath));
-    }
-};
 
 } // namespace Ukkonen
 } // namespace Builders

--- a/suffixtree/include/Penjing/SuffixTree/Builders/Ukkonen/Split.hpp
+++ b/suffixtree/include/Penjing/SuffixTree/Builders/Ukkonen/Split.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Rerito
+// Copyright (c) 2021-2022, Rerito
 // SPDX-License-Identifier: MIT
 
 #pragma once
@@ -19,7 +19,7 @@ namespace Ukkonen {
 namespace CPO {
 
 // /!\ Do not use Split outside of Ukkonen builder
-class Split : private Algorithm::MutatingNodeAlgorithm
+class Split : public Algorithm::MutatingNodeAlgorithm
 {
 private:
     template< typename Node, typename NodeFactory >
@@ -86,29 +86,6 @@ inline namespace Cust {
 inline constexpr CPO::Split split{};
 
 } // namespace Cust
-
-struct SplitPolicy
-{
-    template< typename Node, typename NodeFactory >
-    constexpr decltype(auto) split(
-        Node& node,
-        typename Node::TransitionType& branch,
-        std::ranges::range_difference_t< typename Node::StringViewType >
-            branchingPoint,
-        NodeFactory&& factory) const
-        noexcept(noexcept(Cust::split(
-            node,
-            branch,
-            branchingPoint,
-            std::forward< NodeFactory >(factory))))
-    {
-        return Cust::split(
-            node,
-            branch,
-            branchingPoint,
-            std::forward< NodeFactory >(factory));
-    }
-};
 
 } // namespace Ukkonen
 } // namespace Builders

--- a/suffixtree/include/Penjing/SuffixTree/Builders/Ukkonen/TestAndSplit.hpp
+++ b/suffixtree/include/Penjing/SuffixTree/Builders/Ukkonen/TestAndSplit.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Rerito
+// Copyright (c) 2021-2022, Rerito
 // SPDX-License-Identifier: MIT
 
 #pragma once
@@ -9,6 +9,8 @@
 #include "../../Concepts/Node.hpp"
 #include "../../Core/UnsafeTag.hpp"
 
+#include "Split.hpp"
+
 namespace Penjing {
 namespace SuffixTree {
 namespace Builders {
@@ -16,14 +18,9 @@ namespace Ukkonen {
 
 namespace CPO {
 
-template< typename Splitter >
-class TestAndSplit
-    : private Algorithm::MutatingNodeAlgorithm
-    , private Splitter
+template< auto Splitter = Cust::split >
+class TestAndSplit : public Algorithm::MutatingNodeAlgorithm
 {
-private:
-    using Splitter::split;
-
 public:
     template< typename Node, typename NodeFactory >
         requires(Concepts::Node< Node >)
@@ -51,7 +48,7 @@ public:
 
         // Now a new node must be created to make the implicit state explicit
         // and allow branching from it.
-        auto& newNode = split(
+        auto& newNode = Splitter(
             node,
             t,
             std::ranges::size(wordPath),
@@ -65,28 +62,10 @@ public:
 
 inline namespace Cust {
 
-template< typename Splitter >
+template< auto Splitter = split >
 inline constexpr CPO::TestAndSplit< Splitter > testAndSplit{};
 
 } // namespace Cust
-
-template< typename Splitter >
-struct TestAndSplitPolicy
-{
-    template< typename Node, typename NodeFactory >
-    constexpr auto testAndSplit(
-        Node& node,
-        typename Node::StringViewType const& wordPath,
-        typename Node::CharType expansion,
-        NodeFactory&& makeNode) const
-    {
-        return Cust::testAndSplit< Splitter >(
-            node,
-            wordPath,
-            expansion,
-            std::forward< NodeFactory >(makeNode));
-    }
-};
 
 } // namespace Ukkonen
 } // namespace Builders

--- a/suffixtree/include/Penjing/SuffixTree/Concepts/HasStringStorage.hpp
+++ b/suffixtree/include/Penjing/SuffixTree/Concepts/HasStringStorage.hpp
@@ -1,0 +1,30 @@
+// Copyright (c) 2022, Rerito
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <concepts>
+
+#include <Penjing/Meta/Access.hpp>
+#include <Penjing/Meta/IsDetected.hpp>
+
+#include "../Algorithm/MutatingTreeAlgorithm.hpp"
+
+namespace Penjing {
+namespace SuffixTree {
+namespace Concepts {
+
+namespace Details {
+
+template< typename T >
+using StringStorageType = decltype(std::declval< T >().mutableStringStorage(
+    std::declval< Meta::Access< Algorithm::MutatingTreeAlgorithm > const& >()));
+
+} // namespace Details
+
+template< typename T >
+concept HasStringStorage = Meta::Detected< Details::StringStorageType, T >;
+
+} // namespace Concepts
+} // namespace SuffixTree
+} // namespace Penjing

--- a/suffixtree/include/Penjing/SuffixTree/Core/NakedTree.hpp
+++ b/suffixtree/include/Penjing/SuffixTree/Core/NakedTree.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Rerito
+// Copyright (c) 2021-2022, Rerito
 // SPDX-License-Identifier: MIT
 
 #pragma once
@@ -52,19 +52,16 @@ private:
 
 public:
     template< typename... Args >
-    constexpr decltype(auto) addNode(
-        Meta::Access< Algorithm::MutatingTreeAlgorithm >,
-        Args&&... args) noexcept(noexcept(this->_storage
-                                              .emplace(
-                                                  std::declval< Args&& >()...)))
+    constexpr decltype(auto) addNode(Args&&... args) noexcept(
+        noexcept(this->_storage.emplace(std::declval< Args&& >()...)))
     {
         return _storage.emplace(std::forward< Args >(args)...);
     }
 
     // TODO: Support actual removal
-    constexpr void removeNode(
-        Meta::Access< Algorithm::MutatingTreeAlgorithm >,
-        NodeType& node) = delete;
+    constexpr void removeNode(NodeType& node) = delete;
+
+    constexpr NodeType& mutableRoot() noexcept { return _root; }
 };
 
 } // namespace Core

--- a/suffixtree/include/Penjing/SuffixTree/Core/NakedTree.hpp
+++ b/suffixtree/include/Penjing/SuffixTree/Core/NakedTree.hpp
@@ -64,7 +64,7 @@ public:
     }
 
     constexpr NodeType& mutableRoot() noexcept { return _root; }
-    constexpr NodeType const& root() const noexcept{ return _root; }
+    constexpr NodeType const& root() const noexcept { return _root; }
 
     constexpr auto nodeFactory()
     {

--- a/suffixtree/include/Penjing/SuffixTree/Core/NakedTree.hpp
+++ b/suffixtree/include/Penjing/SuffixTree/Core/NakedTree.hpp
@@ -26,6 +26,9 @@ class MutatingTreeAlgorithm;
 
 namespace Core {
 
+// A NakedTree is a suffix tree that only manages its own nodes.
+// It works with string views and assumes that the views will remain valid
+// during the tree lifecycle.
 template<
     typename Str,
     typename StrView,
@@ -37,6 +40,8 @@ template<
 class NakedTree
 {
 public:
+    using StringType = Str;
+    using StringViewType = StrView;
     using CharType = std::ranges::range_value_t< Str >;
     using DiffType = std::ranges::range_difference_t< Str >;
     using NodeType = Node< Str, StrView, NodeTraits >;
@@ -58,10 +63,15 @@ public:
         return _storage.emplace(std::forward< Args >(args)...);
     }
 
-    // TODO: Support actual removal
-    constexpr void removeNode(NodeType& node) = delete;
-
     constexpr NodeType& mutableRoot() noexcept { return _root; }
+    constexpr NodeType const& root() const noexcept{ return _root; }
+
+    constexpr auto nodeFactory()
+    {
+        return [this](auto&&... args) -> decltype(auto) {
+            return addNode(std::forward< decltype(args) >(args)...);
+        };
+    }
 };
 
 } // namespace Core

--- a/suffixtree/include/Penjing/SuffixTree/Core/NakedTree.hpp
+++ b/suffixtree/include/Penjing/SuffixTree/Core/NakedTree.hpp
@@ -34,7 +34,7 @@ template<
     typename StorageTraits =
         Storage::Bindings::ArrayList< std::allocator< Str >, 64u > >
     requires Concepts::String< Str > && Concepts::StringView< Str, StrView >
-class Tree
+class NakedTree
 {
 public:
     using CharType = std::ranges::range_value_t< Str >;

--- a/suffixtree/include/Penjing/SuffixTree/Core/Tree.hpp
+++ b/suffixtree/include/Penjing/SuffixTree/Core/Tree.hpp
@@ -1,0 +1,75 @@
+// Copyright (c) 2022, Rerito
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <Penjing/Meta/Access.hpp>
+
+#include <Penjing/Storage/Bindings/ArrayList.hpp>
+#include <Penjing/Storage/Store.hpp>
+
+#include "../Concepts/HasStringStorage.hpp"
+
+namespace Penjing {
+namespace SuffixTree {
+
+namespace Algorithm {
+
+class MutatingTreeAlgorithm;
+
+} // namespace Algorithm
+
+namespace Core {
+
+// The Tree class is a self-sufficient (generalized) suffix tree class:
+// It holds the strings being added to the tree on top of the tree itself.
+template<
+    typename UnderlyingTree,
+    typename StringStorageTraits =
+        Storage::Bindings::ArrayList< std::allocator< UnderlyingTree >, 64u > >
+class Tree
+{
+public:
+    using NodeType = typename UnderlyingTree::NodeType;
+    using StringType = typename UnderlyingTree::StringType;
+    using StringViewType = typename UnderlyingTree::StringViewType;
+    using CharType = typename UnderlyingTree::CharType;
+
+private:
+    using StringStorage = Storage::Store< StringType, StringStorageTraits >;
+
+private:
+    StringStorage _stringStorage;
+    UnderlyingTree _nakedTree;
+
+public:
+    constexpr auto& mutableStringStorage(
+        Meta::Access< Algorithm::MutatingTreeAlgorithm > const&) noexcept
+    {
+        return _stringStorage;
+    }
+
+    constexpr auto&
+    mutableRoot(Meta::Access< Algorithm::MutatingTreeAlgorithm > const&) noexcept(
+        noexcept(_nakedTree.mutableRoot()))
+    {
+        return _nakedTree.mutableRoot();
+    }
+
+    constexpr auto const& root() const noexcept(noexcept(_nakedTree.root()))
+    {
+        return _nakedTree.root();
+    }
+
+    constexpr auto
+    nodeFactory(Meta::Access< Algorithm::MutatingTreeAlgorithm > const&) noexcept(
+        noexcept(_nakedTree.nodeFactory()))
+    {
+        return _nakedTree.nodeFactory();
+    }
+};
+
+} // namespace Core
+
+} // namespace SuffixTree
+} // namespace Penjing

--- a/suffixtree/test/include/BananaFixture.hpp
+++ b/suffixtree/test/include/BananaFixture.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Rerito
+// Copyright (c) 2021-2022, Rerito
 // SPDX-License-Identifier: MIT
 
 #pragma once
@@ -10,7 +10,7 @@
 
 #include <gtest/gtest.h>
 
-#include <Penjing/Storage/Bindings/StdUnorderedMap.hpp>
+#include <Penjing/Storage/Bindings/StdMap.hpp>
 
 #include <Penjing/SuffixTree/Algorithm/MutatingNodeAlgorithm.hpp>
 #include <Penjing/SuffixTree/Core/Node.hpp>
@@ -28,7 +28,7 @@ protected:
     using NodeType = Core::Node<
         std::string,
         std::string_view,
-        Storage::Bindings::StdUnorderedMap< std::allocator< std::string > > >;
+        Storage::Bindings::StdMap< std::allocator< std::string > > >;
 
     BananaFixture();
     ~BananaFixture() = default;

--- a/suffixtree/test/include/Dump.hpp
+++ b/suffixtree/test/include/Dump.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Rerito
+// Copyright (c) 2021-2022, Rerito
 // SPDX-License-Identifier: MIT
 
 #pragma once
@@ -14,7 +14,7 @@ namespace Test {
 
 class Dump
 {
-
+private:
     template< typename Node >
         requires(Concepts::Node< Node >)
     constexpr void dump(Node const& node, std::ostream& ostream, size_t offset)

--- a/suffixtree/test/include/ToStream.hpp
+++ b/suffixtree/test/include/ToStream.hpp
@@ -1,0 +1,45 @@
+// Copyright (c) 2021-2022, Rerito
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <queue>
+
+#include <Penjing/SuffixTree/Concepts/Node.hpp>
+
+namespace Penjing {
+namespace SuffixTree {
+namespace Test {
+
+class ToStream
+{
+public:
+    template< typename Node, typename OStream >
+    constexpr void operator()(Node const& node, OStream& ostream) const
+    {
+        using NodeRefW = decltype(std::cref(node));
+        std::queue< NodeRefW > toVisit;
+        toVisit.push(std::cref(node));
+
+        while (!toVisit.empty()) {
+            auto const& currentNode = toVisit.front().get();
+            toVisit.pop();
+
+            auto transitions = currentNode.transitions();
+            for (auto t : transitions) {
+                ostream << "[" << t.get().label() << "]";
+                toVisit.emplace(std::cref(*t.get().target()));
+            }
+        }
+    }
+};
+
+inline namespace Cust {
+
+inline constexpr ToStream toStream{};
+
+} // namespace Cust
+
+} // namespace Test
+} // namespace SuffixTree
+} // namespace Penjing

--- a/suffixtree/test/src/BananaFixture.cpp
+++ b/suffixtree/test/src/BananaFixture.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Rerito
+// Copyright (c) 2021-2022, Rerito
 // SPDX-License-Identifier: MIT
 
 #include <ranges>
@@ -30,7 +30,7 @@ BananaFixture::BananaFixture()
     addTransition(n_root, {start + 1, start + 2}, &n_a);
     addTransition(n_root, {start, end}, &n_banana_);
     addTransition(n_root, {start + 2, start + 4}, &n_na);
-    addTransition(n_root, {start+6, end}, &n_);
+    addTransition(n_root, {start + 6, end}, &n_);
 
     addTransition(n_a, {end - 1, end}, &n_a_);
     addTransition(n_a, {start + 2, start + 4}, &n_ana);

--- a/suffixtree/test/src/SuffixTree.cpp
+++ b/suffixtree/test/src/SuffixTree.cpp
@@ -5,12 +5,12 @@
 
 #include <gtest/gtest.h>
 
-#include <Penjing/SuffixTree/Core/Tree.hpp>
+#include <Penjing/SuffixTree/Core/NakedTree.hpp>
 
 TEST(CoreTree, Creation)
 {
     using TreeType =
-        Penjing::SuffixTree::Core::Tree< std::string, std::string_view >;
+        Penjing::SuffixTree::Core::NakedTree< std::string, std::string_view >;
 
     using NodeType = TreeType::NodeType;
     using TransitionType = NodeType::TransitionType;

--- a/suffixtree/test/src/SuffixTree.cpp
+++ b/suffixtree/test/src/SuffixTree.cpp
@@ -1,16 +1,28 @@
-// Copyright (c) 2021, Rerito
+// Copyright (c) 2021-2022, Rerito
 // SPDX-License-Identifier: MIT
 
 #include <string>
 
 #include <gtest/gtest.h>
 
+#include <Penjing/Storage/Bindings/ArrayList.hpp>
+
 #include <Penjing/SuffixTree/Core/NakedTree.hpp>
+#include <Penjing/SuffixTree/Core/Tree.hpp>
+
+#include <Penjing/SuffixTree/Builders/TreeBuild.hpp>
+#include <Penjing/SuffixTree/Builders/Ukkonen.hpp>
+
+#include <Dump.hpp>
+
+using namespace Penjing;
+using namespace Penjing::SuffixTree;
+using namespace Penjing::SuffixTree::Test;
 
 TEST(CoreTree, Creation)
 {
-    using TreeType =
-        Penjing::SuffixTree::Core::NakedTree< std::string, std::string_view >;
+    using NakedTreeType = Core::NakedTree< std::string, std::string_view >;
+    using TreeType = Core::Tree< NakedTreeType >;
 
     using NodeType = TreeType::NodeType;
     using TransitionType = NodeType::TransitionType;
@@ -24,4 +36,10 @@ TEST(CoreTree, Creation)
             NodeType::TransitionContainerType,
             std::unordered_map< char, TransitionType > >,
         "The Node's storage should be an std::unordered_map");
+
+    TreeType tree{};
+
+    ukkonenBuild(tree, std::string{"cacao$"});
+
+    dump(tree.root(), std::cout);
 }

--- a/suffixtree/test/src/Ukkonen/Build.cpp
+++ b/suffixtree/test/src/Ukkonen/Build.cpp
@@ -25,11 +25,6 @@ using namespace Penjing::SuffixTree;
 using namespace Penjing::SuffixTree::Test;
 using namespace Penjing::SuffixTree::Builders::Ukkonen;
 
-inline constexpr CPO::Build<
-    CanonizePolicy,
-    UpdatePolicy< CanonizePolicy, TestAndSplitPolicy< SplitPolicy > > >
-    build{};
-
 using NodeType = Core::Node<
     std::string,
     std::string_view,
@@ -59,7 +54,7 @@ void treeBuildTest(std::string const& str, std::string const& expectedTree)
     NodeFactory< NodeType > factory{};
     std::stringstream output;
     auto& root = factory();
-    ::build(root, str, factory);
+    build<>(root, str, factory);
     toStream(root, output);
 
     ASSERT_EQ(output.str(), expectedTree);
@@ -93,16 +88,16 @@ TEST(UkkonenBuild, GST)
 
     std::string banana = "banana$";
     auto& root = factory();
-    ::build(root, banana, factory);
+    build<>(root, banana, factory);
 
     std::string cacao = "cacao$";
-    ::build(root, cacao, factory);
+    build<>(root, cacao, factory);
 
     std::string curacao = "curacao$";
-    ::build(root, curacao, factory);
+    build<>(root, curacao, factory);
 
     std::string burundi = "burundi$";
-    ::build(root, burundi, factory);
+    build<>(root, burundi, factory);
     dump(root, std::cout);
 }
 

--- a/suffixtree/test/src/Ukkonen/Build.cpp
+++ b/suffixtree/test/src/Ukkonen/Build.cpp
@@ -1,7 +1,11 @@
-// Copyright (c) 2021, Rerito
+// Copyright (c) 2021-2022, Rerito
 // SPDX-License-Identifier: MIT
 
+#include <sstream>
+
 #include <gtest/gtest.h>
+
+#include <Penjing/Storage/Bindings/StdMap.hpp>
 
 #include <Penjing/SuffixTree/Algorithm/CompareNodes.hpp>
 
@@ -11,37 +15,85 @@
 #include <Penjing/SuffixTree/Builders/Ukkonen/TestAndSplit.hpp>
 #include <Penjing/SuffixTree/Builders/Ukkonen/Update.hpp>
 
-#include <BananaFixture.hpp>
+#include <Penjing/SuffixTree/Core/Node.hpp>
+
 #include <Dump.hpp>
 #include <NodeFactory.hpp>
+#include <ToStream.hpp>
 
 using namespace Penjing::SuffixTree;
 using namespace Penjing::SuffixTree::Test;
 using namespace Penjing::SuffixTree::Builders::Ukkonen;
-
-using UkkonenBuildFixture = BananaFixture;
 
 inline constexpr CPO::Build<
     CanonizePolicy,
     UpdatePolicy< CanonizePolicy, TestAndSplitPolicy< SplitPolicy > > >
     build{};
 
-TEST_F(UkkonenBuildFixture, Mississipi)
+using NodeType = Core::Node<
+    std::string,
+    std::string_view,
+    Penjing::Storage::Bindings::StdMap< std::allocator< std::string > > >;
+
+// Note on build tests:
+// The compact string representation of the tree is the concatenation
+// of the transition labels as seen going through a BFS
+// Since we are using a regular `std::map` as the transition container we
+// also get them in the lexicographical order
+//
+// For instance the string "cacao$" has the following suffix tree:
+// o - [$] - o
+//   - [a] - o - [cao$] - o
+//             - [o$] - o
+//   - [ca] - o - [cao$] - o
+//              - [o$] - o
+//   - [o$] - o
+//
+// Which leads to the compact representation:
+// [$][a][ca][o$][cao$][o$][cao$][o$]
+
+namespace {
+
+void treeBuildTest(std::string const& str, std::string const& expectedTree)
 {
     NodeFactory< NodeType > factory{};
+    std::stringstream output;
     auto& root = factory();
-    std::string mississipi = "mississipi$";
-    ::build(root, mississipi, factory);
-    dump(root, std::cout);
+    ::build(root, str, factory);
+    toStream(root, output);
+
+    ASSERT_EQ(output.str(), expectedTree);
 }
 
-TEST_F(UkkonenBuildFixture, Build)
+}
+
+TEST(UkkonenBuild, Cacao)
+{
+    std::string cacao = "cacao$";
+    std::string expectedTree = "[$][a][ca][o$][cao$][o$][cao$][o$]";
+
+    treeBuildTest(cacao, expectedTree);
+}
+
+TEST(UkkonenBuild, Mississippi)
+{
+
+    std::string mississipi = "mississippi$";
+
+    std::string expectedTree =
+        "[$][i][mississippi$][p][s][$][ppi$][ssi][i$][pi$][i][si][ppi$]"
+        "[ssippi$][ppi$][ssippi$][ppi$][ssippi$]";
+
+    treeBuildTest(mississipi, expectedTree);
+}
+
+TEST(UkkonenBuild, GST)
 {
     NodeFactory< NodeType > factory{};
 
+    std::string banana = "banana$";
     auto& root = factory();
-    ::build(root, _banana, factory);
-    EXPECT_TRUE(Algorithm::compareNodes(root, _nodes.at(0)));
+    ::build(root, banana, factory);
 
     std::string cacao = "cacao$";
     ::build(root, cacao, factory);
@@ -54,12 +106,14 @@ TEST_F(UkkonenBuildFixture, Build)
     dump(root, std::cout);
 }
 
-TEST_F(UkkonenBuildFixture, mississippixsissy)
+TEST(UkkonenBuild, Mississippixsissy)
 {
-    NodeFactory< NodeType > factory{};
-
-    auto& root = factory();
     std::string test = "mississippixsissy$";
-    ::build(root, test, factory);
-    dump(root, std::cout);
+    std::string expectedTree =
+        "[$][i][mississippixsissy$][p][s][xsissy$][y$][ppixsissy$][ss][xsissy$]"
+        "[ixsissy$][pixsissy$][i][s][y$][i][y$][ppixsissy$][ss][i][y$]"
+        "[ppixsissy$][ssippixsissy$][ippixsissy$][y$][ppixsissy$]"
+        "[ssippixsissy$]";
+
+    treeBuildTest(test, expectedTree);
 }

--- a/suffixtree/test/src/Ukkonen/TestAndSplit.cpp
+++ b/suffixtree/test/src/Ukkonen/TestAndSplit.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Rerito
+// Copyright (c) 2021-2022, Rerito
 // SPDX-License-Identifier: MIT
 
 #include <gtest/gtest.h>
@@ -28,11 +28,8 @@ TEST_F(UkkonenTestAndSplitFixture, Common)
     auto const& t = origin.transition('b', Core::UnsafeTag{});
     auto const originalTarget = t.target();
 
-    auto [isEndPoint, newNode] = testAndSplit< SplitPolicy >(
-        origin,
-        std::string_view{ban},
-        't',
-        factory);
+    auto [isEndPoint, newNode] =
+        testAndSplit<>(origin, std::string_view{ban}, 't', factory);
 
     ASSERT_FALSE(isEndPoint);
     ASSERT_EQ(ban, t.label());
@@ -49,11 +46,8 @@ TEST_F(UkkonenTestAndSplitFixture, EndPoint)
     auto& origin = _nodes.at(0);
     std::string ban = "ban";
 
-    auto [isEndPoint, newNode] = testAndSplit< SplitPolicy >(
-        origin,
-        std::string_view{ban},
-        'a',
-        factory);
+    auto [isEndPoint, newNode] =
+        testAndSplit<>(origin, std::string_view{ban}, 'a', factory);
 
     ASSERT_TRUE(isEndPoint);
     ASSERT_EQ(&origin, &newNode);

--- a/suffixtree/test/src/Ukkonen/Update.cpp
+++ b/suffixtree/test/src/Ukkonen/Update.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Rerito
+// Copyright (c) 2021-2022, Rerito
 // SPDX-License-Identifier: MIT
 
 #include <gtest/gtest.h>
@@ -17,15 +17,11 @@ using namespace Penjing::SuffixTree::Test;
 
 using UkkonenUpdateFixture = BananaFixture;
 
-inline constexpr CPO::
-    Update< CanonizePolicy, TestAndSplitPolicy< SplitPolicy > >
-        testUpdate{};
-
 TEST_F(UkkonenUpdateFixture, Basic)
 {
     NodeFactory< NodeType > factory;
     std::string can_ = "can$";
-    auto result = testUpdate(_nodes.at(0), _nodes.at(0), can_, 0, factory);
+    auto result = update<>(_nodes.at(0), _nodes.at(0), can_, 0, factory);
 
     // We added the expansion for the first character in the new string "can$"
     // We should end up in root


### PR DESCRIPTION
This PR defines the abstraction over the low level Builders and Node APIs.
It offers:

- A `Penjing::SuffixTree::Core::NakedTree` class that manages a "naked" suffix tree. The `NakedTree` manages its own nodes lifecycle but only works with views, assuming the underlying string objects are stable.
- A `Penjing::SuffixTree::Core::Tree` class that manages string storage on top of the `NakedTree` 
- A build API to construct the tree for the given string.